### PR TITLE
stop iterating when count matches, not when it's above

### DIFF
--- a/quest-goals/KillGoal.js
+++ b/quest-goals/KillGoal.js
@@ -29,7 +29,7 @@ module.exports = class KillGoal extends QuestGoal {
   }
 
   _targetKilled(target) {
-    if (target.entityReference !== this.config.npc || this.state.count > this.config.count) {
+    if (target.entityReference !== this.config.npc || this.state.count === this.config.count) {
       return;
     }
 


### PR DESCRIPTION
if you let it get above, eventually it will break broadcast's ability to render a progress bar -> 115% instead of 100%..etc